### PR TITLE
added handling of timeout errors to GEMHwDevice

### DIFF
--- a/gemdaq-testing/gemhardware/include/gem/hw/GEMHwDevice.h
+++ b/gemdaq-testing/gemhardware/include/gem/hw/GEMHwDevice.h
@@ -8,6 +8,8 @@
 
 #include "uhal/uhal.hpp"
 
+#define MAX_VFAT_RETRIES 25
+
 typedef uhal::exception::exception uhalException;
 
 namespace uhal {
@@ -22,13 +24,10 @@ namespace gem {
   
   namespace hw {
     
-    class GEMHwDevice//: public xdaq::Application, public xdata::ActionListener
+    class GEMHwDevice
       {
       public:
-	//XDAQ_INSTANTIATOR();
-	
 	GEMHwDevice(xdaq::Application* xdaqApp);
-	  //throw (xdaq::exception::Exception);
 
 	virtual ~GEMHwDevice();
 	


### PR DESCRIPTION
Retries the IPBus transaction in the case of one of the failures below:
"amount of data"
"INFO CODE = 0x4L"
"INFO CODE = 0x6L"
"timed out"
"ControlHub error code is: 4"

Maximum number of retries per transaction is set to 25 (probably too high, but to be safe)
Need to check that this retry always gets the information expected, i.e., if we fail to read a register that is updated regularly, will we get the expected packet?
