### PR TITLE
rolled back changes that introduced memory leak

### DIFF
--- a/gemdaq-testing/gemhardware/include/gem/hw/GEMHwDevice.h
+++ b/gemdaq-testing/gemhardware/include/gem/hw/GEMHwDevice.h
@@ -39,7 +39,18 @@ namespace gem {
 	} DeviceErrors;
 	
       public:
+	/** 
+	 * GEMHwDevice constructor 
+	 * @param xdaqApp pointer to xdaq::Application
+	 **/
 	GEMHwDevice(xdaq::Application* xdaqApp);
+	/*
+	GEMHwDevice(xdaq::Application* xdaqApp,
+	            std::string& addressFileName,
+	            std::string& ipAddress,
+	            std::string& controlHubAddress,
+		    );
+	*/
 
 	virtual ~GEMHwDevice();
 	
@@ -59,18 +70,28 @@ namespace gem {
 	
 	/**
 	 *Generic read/write functions or IPBus devices
-	 *operation will be the same for the GLIB, MP7, VFAT2/3, 
+	 * operation will be the same for the GLIB, MP7, VFAT2/3, 
 	 * and AMC13 ( we should use the already defined AMC13, rather than write our own,
-	 unless there are GEM specific functions we need to implement)
+	 * unless there are GEM specific functions we need to implement)
 	 */
-	//perform a single read transaction
+
+	/** readReg(std::string const& regName)
+	 * @param regName name of the register to read 
+	 * @retval returns the 32 bit unsigned value in the register
+	 */
 	virtual uint32_t readReg( std::string const& regName);
+
+	/** readReg(std::string const& regPrefix, std::string const& regName)
+	 * @param regPrefix prefix in the address table, possibly root nodes
+	 * @param regName name of the register to read from the address table
+	 * @retval returns the 32 bit unsigned value
+	 */
 	virtual uint32_t readReg( std::string const& regPrefix,
-				  std::string const& regName) {
+			  std::string const& regName) {
 	  std::string name = regPrefix+"."+regName;
 	  return readReg(name); };
 	//read list of registers in a single transaction (one dispatch call) into the supplied vector regList
-	virtual void     readRegs( std::vector<std::pair<std::string, uint32_t> > &regList);
+	void     readRegs( std::vector<std::pair<std::string, uint32_t> > &regList);
 
 	//perform a single write transaction
 	virtual void     writeReg( std::string const& regName, uint32_t const);
@@ -84,7 +105,7 @@ namespace gem {
 	virtual void     writeValueToRegs(std::vector<std::string> const& regList, uint32_t const& regValue);
 	
 	//write zero to a single register
-	virtual void     zeroReg(  std::string const& regName);
+	virtual void     zeroReg(  std::string const& regName) { writeReg(regName,0); };
 	//write zero to a list of registers in a single transaction (one dispatch call) using the supplied vector regNames
 	virtual void     zeroRegs( std::vector<std::string> const& regNames);
 
@@ -99,11 +120,11 @@ namespace gem {
 	// These methods provide access to the member variables
 	// specifying the uhal address table name and the IPbus protocol
 	// version.
-	std::string getAddressTableFileName() const { return addressTable_;   };
-	std::string getIPbusProtocolVersion() const { return ipbusProtocol_;  };
-	std::string getDeviceBaseNode()       const { return deviceBaseNode_; };
-	std::string getDeviceIPAddress()      const { return deviceIPAddr_;   };
-	std::string getDeviceID()             const { return deviceID_;       };
+	const std::string getAddressTableFileName() const { return addressTable_;   };
+	const std::string getIPbusProtocolVersion() const { return ipbusProtocol_;  };
+	const std::string getDeviceBaseNode()       const { return deviceBaseNode_; };
+	const std::string getDeviceIPAddress()      const { return deviceIPAddr_;   };
+	const std::string getDeviceID()             const { return deviceID_;       };
 
 	void setAddressTableFileName(std::string const& name) {
 	  addressTable_ = "file://${BUILD_HOME}/data/"+name; };

--- a/gemdaq-testing/gemhardware/include/gem/hw/vfat/HwVFAT2.h
+++ b/gemdaq-testing/gemhardware/include/gem/hw/vfat/HwVFAT2.h
@@ -72,8 +72,10 @@ namespace gem {
 
 	  //special implementation of the read/write for VFATs
 	  virtual uint32_t readReg( std::string const& regName);
-	  virtual uint32_t readReg( std::string const& regPrefix,
+	  /*
+	    virtual uint32_t readReg( std::string const& regPrefix,
 				    std::string const& regName);
+	  */
 	  //  std::string name = regPrefix+"."+regName;
 	  //  return readReg(name); };
 	  //void     readRegs( std::vector<std::pair<std::string, uint32_t> > &regList);

--- a/gemdaq-testing/gemhardware/src/common/HwVFAT2.cc
+++ b/gemdaq-testing/gemhardware/src/common/HwVFAT2.cc
@@ -98,14 +98,14 @@ uint32_t gem::hw::vfat::HwVFAT2::readReg(std::string const& regName)
 {
   //Maybe want to use a lock to prevent hammering the HW device
   //uint32_t regValue;
-  //regValue = gem::hw::GEMHwDevice::readReg(getDeviceBaseNode()+"."+regName);
+  //regValue = GEMHwDevice::readReg(getDeviceBaseNode()+"."+regName);
   //return regValue;
-  //return gem::hw::GEMHwDevice::readReg(getDeviceBaseNode()+"."+regName);
-  return readReg(getDeviceBaseNode(),regName);
+  return GEMHwDevice::readReg(getDeviceBaseNode()+"."+regName);
+  //return GEMHwDevice::readReg(getDeviceBaseNode(),regName);
 }
 
-//void gem::hw::vfat::HwVFAT2::readVFAT2Counters(gem::hw::vfat::VFAT2ControlParams &params)
 // read VFAT chipID and upset/hit counters into vfatParams_ object
+//void gem::hw::vfat::HwVFAT2::readVFAT2Counters(gem::hw::vfat::VFAT2ControlParams &params)
 void gem::hw::vfat::HwVFAT2::readVFAT2Counters()
 {
   vfatParams_.chipID       = getChipID();


### PR DESCRIPTION
Calling GEMHwDevice::readReg(prefix, name) causes a memory leak for some reason that I haven't tracked down.
Rolling back the change allows the code to work in the old way for now
