### PR TITLE
include iomanip, change default ip address

### DIFF
--- a/gemdaq-testing/gemsupervisor/src/common/GEMGLIBSupervisorWeb.cc
+++ b/gemdaq-testing/gemsupervisor/src/common/GEMGLIBSupervisorWeb.cc
@@ -2,6 +2,7 @@
 #include "gem/supervisor/tbutils/ThresholdEvent.h"
 #include "gem/hw/vfat/HwVFAT2.h"
 
+#include <iomanip>
 #include <ctime>
 #include <sstream>
 #include <cstdlib>
@@ -16,7 +17,7 @@ void gem::supervisor::GEMGLIBSupervisorWeb::ConfigParams::registerFields(xdata::
 
     outFileName  = "";
 
-    deviceIP      = "192.168.0.115";
+    deviceIP      = "192.168.0.175";
     deviceName    = (xdata::String)"VFAT13";
     deviceNum     = -1;
     triggerSource = 0x2; 


### PR DESCRIPTION
1) Some time ago there are started appearing complains about "setfill" and "setw" during compilation. This is fixed by inclusion of <iomanip>: http://www.cplusplus.com/reference/iomanip/

2) Changed default ip address from 192.168.0.115 to 192.168.0.175