### PR TITLE
Fixed bug in filling of summary VFAT plots

### DIFF
--- a/gem-light-dqm/dqm-root/src/common/VFAT_histogram.cxx
+++ b/gem-light-dqm/dqm-root/src/common/VFAT_histogram.cxx
@@ -66,11 +66,11 @@ class VFAT_histogram: public Hardware_histogram
             channelFired = true;
           }
         }
-        if (channelFired) {
-          latencyScan->Fill(latency);
-          thresholdScanChip->Fill(deltaV);
-        }
       }// end loop on channels
+      if (channelFired) {
+        latencyScan->Fill(latency);
+        thresholdScanChip->Fill(deltaV);
+      }
     }
   private:
     TH1F* b1010;


### PR DESCRIPTION
latencyScan and thresholdScanChip were being filled once per fired channel, rather than once per event in which a (possibly more) channels fired
- potentially other interesting per chip threshold plots are (mentioned but not implemented in this bugfix):
  - 2,3,4,5 adjacent strips fired during threshold scan
  - at least 5,10,20 channels fired during threshold scan
