### PR TITLE
Use chipID rather than slot in quick DQM folder

### DIFF
--- a/gem-light-dqm/dqm-root/src/common/gemTreeReader.cxx
+++ b/gem-light-dqm/dqm-root/src/common/gemTreeReader.cxx
@@ -222,8 +222,8 @@ private:
             char vslot_ch[2];   //char used to put VFAT number into directory name
             vslot_ch[0] = '\0';
             std::unique_ptr<gem::readout::GEMslotContents> slotInfo_ = std::unique_ptr<gem::readout::GEMslotContents> (new gem::readout::GEMslotContents("slot_table.csv"));     
-            int vslot = slotInfo_->GEBslotIndex(v->ChipID());  //converts Chip ID into VFAT slot number
-            sprintf(vslot_ch, "%d", vslot);
+            int vslot = v->ChipID();
+            sprintf(vslot_ch, "0x%03x", vslot);
             strcat(dirvfat,"VFAT-");
             strcat(dirvfat, vslot_ch);
             int vID = v->ChipID();


### PR DESCRIPTION
Propose to have simple, i.e., not full DQM, plots based solely on electronics information, rather than physical mapping.
Removes dependence of quick distributions from VFAT to GEB mapping
Agree that the future will have a run configuration exported to the DB which can then be used to make properly mapped plots, but still argue that for "lightDQM" this should _not_ be the standard
